### PR TITLE
Change name of Watopia spawn point to public (not event-only) route

### DIFF
--- a/src/RoadCaptain.Adapters/worlds.json
+++ b/src/RoadCaptain.Adapters/worlds.json
@@ -24,7 +24,7 @@
       },
       {
         "segmentId": "watopia-bambino-fondo-001-after-after-after-after-after-after",
-        "zwiftRouteName": "Big Loop Reverse",
+        "zwiftRouteName": "Two Bridges Loop",
         "direction": "BtoA",
         "sport": "Both"
       },


### PR DESCRIPTION
Spawn point with route name "Big Loop Reverse" uses an event-only route name. Switch to a "public" route with the same spawn point and direction.